### PR TITLE
Add macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,3 +168,27 @@ impl<B: PartialOrd, O> LowerPartialFunctionBuilder<B, O> {
         LowerPartialFunction { funcs: self.funcs }
     }
 }
+
+/// More convenient syntax to create a partial function
+#[macro_export]
+macro_rules! partfn {
+    ( $( [$start:expr, $end:expr]: $var:ident -> $f:expr,)* ) => {
+        {
+            let mut func = PartialFunction::new();
+            $( func = func.with($start, $end, Box::new(|$var| $f)); )*
+            func.build()
+        }
+    };
+}
+
+/// More convenient syntax to create a lower partial function
+#[macro_export]
+macro_rules! lowpartfn {
+    ( $( [$bound:expr]: $var:ident -> $f:expr,)* ) => {
+        {
+            let mut func = LowerPartialFunction::new();
+            $( func = func.with($bound, Box::new(|$var| $f)); )*
+            func.build()
+        }
+    };
+}

--- a/tests/tests_macro.rs
+++ b/tests/tests_macro.rs
@@ -1,0 +1,126 @@
+extern crate partial_function;
+
+#[cfg(test)]
+#[allow(unused_variables)]
+mod tests {
+    use partial_function::*;
+    #[test]
+    fn single() {
+        let p = partfn! {
+            [0.0, 1.0]: x -> x,
+        };
+        assert_eq!(Some(0.5), p.eval(0.5));
+    }
+    #[test]
+    fn single_start() {
+        let p = partfn! {
+            [0.0, 1.0]: x -> x,
+        };
+        assert_eq!(Some(0.0), p.eval(0.0));
+    }
+    #[test]
+    fn single_ending() {
+        let p = partfn! {
+            [0.0, 1.0]: x -> x,
+        };
+        assert_eq!(Some(1.0), p.eval(1.0));
+    }
+    #[test]
+    fn single_nan() {
+        let p = partfn! {
+            [0.0, 1.0]: x -> x,
+        };
+        assert!(p.eval(999.0).is_none());
+    }
+    #[test]
+    fn dual_start() {
+        let p = partfn! {
+            [1.0, 2.0]: x -> 5.0,
+            [0.0, 1.0]: x -> x,
+        };
+        assert_eq!(Some(5.0), p.eval(1.0));
+    }
+    #[test]
+    fn dual_end() {
+        let p = partfn! {
+            [0.0, 1.0]: x -> x,
+            [1.0, 2.0]: x -> 5.0,
+        };
+        assert_eq!(Some(5.0), p.eval(1.0));
+    }
+    #[test]
+    #[should_panic]
+    fn intersect_start() {
+        partfn! {
+            [0.0, 1.0]: x -> x,
+            [-0.5, 0.5]: x -> 5.0,
+        };
+    }
+    #[test]
+    #[should_panic]
+    fn intersect_end() {
+        partfn! {
+            [0.0, 1.0]: x -> x,
+            [0.5, 2.0]: x -> 5.0,
+        };
+    }
+    #[test]
+    #[should_panic]
+    fn intersect_inner() {
+        partfn! {
+            [0.0, 1.0]: x -> x,
+            [0.4, 0.6]: x -> 5.0,
+        };
+    }
+    #[test]
+    #[should_panic]
+    fn intersect_outer() {
+        partfn! {
+            [0.0, 1.0]: x -> x,
+            [-2.0, 2.0]: x -> 5.0,
+        };
+    }
+    #[test]
+    #[should_panic]
+    fn intersect_same() {
+        partfn! {
+            [0.0, 1.0]: x -> x,
+            [0.0, 1.0]: x -> 5.0,
+        };
+    }
+
+    #[test]
+    fn lower_partial_normal() {
+        let f = lowpartfn! {
+            [0.0]: x -> 1,
+            [1.0]: x -> 2,
+        };
+        assert_eq!(f.eval(-1.0), None);
+        assert_eq!(f.eval(0.0), Some(1));
+        assert_eq!(f.eval(0.5), Some(1));
+        assert_eq!(f.eval(1.0), Some(2));
+        assert_eq!(f.eval(1000.0), Some(2));
+    }
+
+    #[test]
+    fn lower_partial_inverse_insert() {
+        let f = lowpartfn! {
+            [1.0]: x -> 2,
+            [0.0]: x -> 1,
+        };
+        assert_eq!(f.eval(-1.0), None);
+        assert_eq!(f.eval(0.0), Some(1));
+        assert_eq!(f.eval(0.5), Some(1));
+        assert_eq!(f.eval(1.0), Some(2));
+        assert_eq!(f.eval(1000.0), Some(2));
+    }
+
+    #[test]
+    #[should_panic]
+    fn lower_partial_overlap() {
+        let f = lowpartfn! {
+            [0.0]: x -> 1,
+            [0.0]: x -> 2,
+        };
+    }
+}

--- a/tests/tests_macro.rs
+++ b/tests/tests_macro.rs
@@ -1,5 +1,9 @@
 extern crate partial_function;
 
+// All these tests are the same as those in
+// tests.rs, the only difference is that the
+// macro version is used.
+
 #[cfg(test)]
 #[allow(unused_variables)]
 mod tests {


### PR DESCRIPTION
Using macros to initialize partial functions would (I believe) improve readability, by:
1. Hiding `::new()`, `Box::new()` and `.build()` from the user
2. Making the syntax a bit closer to how a mathematician would write it

To represent
```
f(x) = {
    x     if 0 <= x <   5
    x * 2 if 5 <= x <= 10
}
```
the macro would replace
```
let f = PartialFunction::new()
    .with(0.0, 5.0,  Box::new(|x| x    ))
    .with(5.0, 10.0, Box::new(|x| x * 2))
    .build();
```
with
```
let f = partfn! {
    [0.0, 5.0]: x -> x,
    [5.0, 10.0]: x -> x*2,
};
```

Similarly, 
```
f(x) = {
    x     if 0 <= x <   5
    x * 2 if 5 <= x
}
```
could, instead of being written
```
let f = LowerPartialFunction::new()
    .with(0.0, Box::new(|x| x    ))
    .with(5.0, Box::new(|x| x * 2))
    .build();
```
be declared as
```
let f = lowpartfn! {
    [0.0]: x -> x,
    [5.0]: x -> x*2,
};
```

Note that:
- the syntax is merely a suggestion, the purpose of this pull request is not to impose a syntax but to suggest the use of macros and show that such a macro can be implemented quite easily,
- I am by no means an expert in Rust, and the macro may need to be further sanitized,
- no new tests were added, I merely rewrote the existing tests. Some more tests could be required to verify that the macro behaves properly under all circumstances
